### PR TITLE
Add extension setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,20 @@ Plug  "lpoto/telescope-tasks.nvim"
 
 ## Setup and usage
 
-First load the extension:
+First setup and load the extension:
 
 ```lua
+require("telescope").setup {
+  extensions = {
+    tasks = {
+      theme = "ivy",
+      -- other picker config fields
+      -- NOTE: this setup is optional
+    },
+  },
+}
+
+-- Load the tasks telescope extension
 require("telescope").load_extension("tasks")
 ```
 
@@ -75,6 +86,7 @@ require("telescope").extensions.tasks.tasks()
 > ```
 
 The last opened output may then be toggled with:
+
 ```lua
  require("telescope").extensions.tasks.actions.toggle_last_output()
 ```
@@ -86,8 +98,9 @@ The last opened output may then be toggled with:
 - [x] Show tasks' definitions or output(when available) in the telescope previewer
 - [x] Allow opening the task's output in a separate buffer
 - [x] Allow toggling the latest output
-- [ ] Add setup
-  - [ ] Allow setting a theme in config
-  - [ ] Allow custom mappings
+- [x] Add setup
+  - [x] Allow adding a custom picker setup
+  - [x] Add a theme setup field
   - [ ] Allow configuring output window
+- [ ] Allow scrolling the task output preview
 - [ ] Redo tasks execution so that each step is it's own job

--- a/lua/telescope/_extensions/tasks.lua
+++ b/lua/telescope/_extensions/tasks.lua
@@ -1,5 +1,6 @@
 local enum = require "telescope._extensions.tasks.enum"
 local picker = require "telescope._extensions.tasks.picker"
+local setup = require "telescope._extensions.tasks.setup"
 local actions = require "telescope._extensions.tasks.actions"
 
 -- NOTE: ensure the telescope is loaded
@@ -16,13 +17,22 @@ if not has_telescope then
   )
 end
 
+---Opens the tasks picker and merges the provided opts
+---with the default options provided during the setup.
+---@param opts table|nil
+local function tasks(opts)
+  opts = opts or {}
+  picker(vim.tbl_extend("force", setup.opts, opts))
+end
+
 -- NOTE: create the augroup used by the plugin
 vim.api.nvim_create_augroup(enum.TASKS_AUGROUP, { clear = true })
 
 -- NOTE: register the extension
 return telescope.register_extension {
+  setup = setup.setup,
   exports = {
-    tasks = picker,
+    tasks = tasks,
     actions = actions,
     _picker = picker,
   },

--- a/lua/telescope/_extensions/tasks/mappings.lua
+++ b/lua/telescope/_extensions/tasks/mappings.lua
@@ -1,0 +1,56 @@
+local telescope_actions = require "telescope.actions"
+local actions = require "telescope._extensions.tasks.actions"
+
+local mappings = {}
+
+mappings.keys = {
+  ["<CR>"] = {
+    desc = "Run/Kill",
+    action = actions.select_task,
+  },
+  ["<C-o>"] = {
+    modes = { "n", "i" },
+    desc = "Show output",
+    action = actions.selected_task_output,
+  },
+  ["<C-d>"] = {
+    modes = { "n", "i" },
+    desc = "Delete output",
+    action = actions.delete_selected_task_output,
+  },
+}
+
+---@return string: Mappings description
+function mappings.get_description()
+  local desc = ""
+  for key, cfg in pairs(mappings.keys) do
+    if desc:len() > 0 then
+      desc = desc .. ", "
+    end
+    desc = desc .. key .. " - " .. cfg.desc
+  end
+  return desc
+end
+
+---@param prev_buf number|nil
+---@return function: Attach mappings function
+function mappings.get_attach_mappings(prev_buf)
+  return function(prompt_bufnr, map)
+    for key, cfg in pairs(mappings.keys or {}) do
+      if key == "<CR>" then
+        telescope_actions.select_default:replace(function()
+          cfg.action(prompt_bufnr, prev_buf)
+        end)
+      else
+        for _, mode in ipairs(cfg.modes or {}) do
+          map(mode, key, function()
+            cfg.action(prompt_bufnr, prev_buf)
+          end)
+        end
+      end
+    end
+    return true
+  end
+end
+
+return mappings

--- a/lua/telescope/_extensions/tasks/picker.lua
+++ b/lua/telescope/_extensions/tasks/picker.lua
@@ -2,11 +2,10 @@ local Task = require "telescope._extensions.tasks.model.task"
 local enum = require "telescope._extensions.tasks.enum"
 local finder = require "telescope._extensions.tasks.finder"
 local previewer = require "telescope._extensions.tasks.previewer"
-local actions = require "telescope._extensions.tasks.actions"
+local mappings = require "telescope._extensions.tasks.mappings"
 
 local pickers = require "telescope.pickers"
 local conf = require("telescope.config").values
-local telescope_actions = require "telescope.actions"
 
 local picker = {}
 local prev_buf = nil
@@ -19,23 +18,6 @@ local available_tasks_telescope_picker
 ---@param opts table?: options to pass to the picker
 function picker.available_tasks_picker(opts)
   available_tasks_telescope_picker(opts)
-end
-
-local function attach_picker_mappings()
-  return function(prompt_bufnr, map)
-    telescope_actions.select_default:replace(function()
-      actions.select_task(prompt_bufnr, prev_buf)
-    end)
-    for _, mode in ipairs { "i", "n" } do
-      map(mode, "<C-o>", function()
-        actions.selected_task_output(prompt_bufnr)
-      end)
-      map(mode, "<C-d>", function()
-        actions.delete_selected_task_output(prompt_bufnr, prev_buf)
-      end)
-    end
-    return true
-  end
 end
 
 available_tasks_telescope_picker = function(options)
@@ -69,13 +51,13 @@ available_tasks_telescope_picker = function(options)
     pickers
       .new(opts, {
         prompt_title = "Tasks",
-        results_title = "<CR> - Run/kill , <C-o> - Show output, <C-d> - Delete output",
+        results_title = mappings.get_description(),
         finder = finder.available_tasks_finder(prev_buf),
         sorter = conf.generic_sorter(opts),
         previewer = previewer.task_previewer(),
         dynamic_preview_title = true,
         selection_strategy = "row",
-        attach_mappings = attach_picker_mappings(),
+        attach_mappings = mappings.get_attach_mappings(prev_buf),
       })
       :find()
   end

--- a/lua/telescope/_extensions/tasks/previewer.lua
+++ b/lua/telescope/_extensions/tasks/previewer.lua
@@ -13,12 +13,16 @@ local get_task_definition
 ---@return table: a telescope previewer
 function previewer.task_previewer()
   return previewers.new {
+    title = "Task Preview",
     teardown = function(self)
       pcall(
         vim.api.nvim_buf_delete,
         previewer.old_preview_buf,
         { force = true }
       )
+      if self.state == nil or self.state.bufnr == nil then
+        return
+      end
       local _, winid = pcall(vim.fn.bufwinid, self.state.bufnr)
       self.state.bufnr = nil
       if

--- a/lua/telescope/_extensions/tasks/setup.lua
+++ b/lua/telescope/_extensions/tasks/setup.lua
@@ -1,0 +1,29 @@
+local enum = require "telescope._extensions.tasks.enum"
+
+local setup = {}
+
+setup.opts = {}
+
+---Creates the default picker options from the provided
+---options. If the `theme` field with a string value is added,
+---the telescope theme identified by that value is added to the options.
+---@param opts table
+function setup.setup(opts)
+  if type(opts.theme) == "string" then
+    local theme = require("telescope.themes")["get_" .. opts.theme]
+    if theme == nil then
+      vim.notify(
+        "No such telescope theme: '" .. opts.theme .. "'",
+        vim.log.levels.WARN,
+        {
+          title = enum.TITLE,
+        }
+      )
+    else
+      opts = theme(opts)
+    end
+    setup.opts = vim.tbl_extend("force", setup.opts, opts)
+  end
+end
+
+return setup


### PR DESCRIPTION
- Allow adding a custom picker config 
- Add a theme field

> Example config:
>```lua
>require("telescope").setup {
>  extensions = {
>    tasks = {
>      theme = "ivy",
>      prompt_title = "Custom Tasks Title",
>      selection_strategy = "row",
>      -- ...
>    }
>  }
>}
>```