### PR TITLE
Keep running jobs in the picker, even when unavailable

### DIFF
--- a/lua/telescope/_extensions/tasks/generators/default/hello_world.lua
+++ b/lua/telescope/_extensions/tasks/generators/default/hello_world.lua
@@ -1,17 +1,10 @@
-local Default_generator =
-  require "telescope._extensions.tasks.model.default_generator"
-
----@type Default_generator
-local hello_world = setmetatable({
+return require("telescope._extensions.tasks.model.default_generator"):new {
   name = "Hello World Generator",
-}, Default_generator)
-
-hello_world.generator_fn = function()
-  return {
-    "Hello world!",
-    env = { HELLO_WORLD = "Hello World!" },
-    cmd = "echo $HELLO_WORLD",
-  }
-end
-
-return hello_world
+  generator_fn = function()
+    return {
+      "Hello world!",
+      env = { HELLO_WORLD = "Hello World!" },
+      cmd = "echo $HELLO_WORLD",
+    }
+  end,
+}

--- a/lua/telescope/_extensions/tasks/generators/init.lua
+++ b/lua/telescope/_extensions/tasks/generators/init.lua
@@ -4,6 +4,7 @@ local Generator = require "telescope._extensions.tasks.model.generator"
 local default = require "telescope._extensions.tasks.generators.default"
 
 local generators = {}
+local add_batch
 
 ---Add a custom generator. The generator will run on every BufEnter
 ---Or DirChanged event in the buffers with `buftype`="".
@@ -17,18 +18,7 @@ local generators = {}
 ---  - `generator` (function) The generator function.
 ---  - `opts` (Generator_opts|nil) The generator conditions.
 function generators.add(generator)
-  local ok, added = pcall(function()
-    generator = Generator.new(generator)
-    table.insert(runner.__current_generators, generator)
-    return generator
-  end)
-  if not ok and type(added) == "string" then
-    vim.notify(added, vim.log.levels.WARN, {
-      title = enum.TITLE,
-    })
-  elseif added then
-    runner.run { added }
-  end
+  generators.add_batch { generator }
 end
 
 ---Add a batch of generators at once. This is useful when you want to
@@ -38,26 +28,10 @@ end
 ---@param generators_batch table: A table of generators.
 ---Each generator is the same as the parameter for the `generators.add(generator)` function.
 function generators.add_batch(generators_batch)
-  local ok, added = pcall(function()
-    assert(
-      type(generators_batch) == "table",
-      "A batch of generators must be a table"
-    )
-    local inserted = {}
-    for _, generator in ipairs(generators_batch) do
-      generator = Generator.new(generator)
-      table.insert(inserted, generator)
-      table.insert(runner.__current_generators, generator)
-    end
-    return inserted
-  end)
-  if not ok and type(added) == "string" then
-    vim.notify(added, vim.log.levels.WARN, {
-      title = enum.TITLE,
-    })
-  elseif next(added or {}) then
-    runner.run(added)
-  end
+  runner.__adding = true
+  runner.__adding = true
+  add_batch(generators_batch)
+  runner.__adding = false
 end
 
 ---A table containing the functions, each returning the
@@ -71,6 +45,29 @@ function generators.enable_default()
     table.insert(defaults, generator())
   end
   generators.add_batch(defaults)
+end
+
+add_batch = function(generators_batch)
+  local ok, added = pcall(function()
+    assert(
+      type(generators_batch) == "table",
+      "A batch of generators must be a table"
+    )
+    local inserted = {}
+    for _, generator in ipairs(generators_batch) do
+      generator = Generator:new(generator)
+      table.insert(inserted, generator)
+      table.insert(runner.__current_generators, generator)
+    end
+    return inserted
+  end)
+  if not ok and type(added) == "string" then
+    pcall(vim.notify, added, vim.log.levels.WARN, {
+      title = enum.TITLE,
+    })
+  elseif next(added or {}) then
+    pcall(runner.run, buf, added, true, true)
+  end
 end
 
 return generators

--- a/lua/telescope/_extensions/tasks/generators/runner.lua
+++ b/lua/telescope/_extensions/tasks/generators/runner.lua
@@ -6,31 +6,57 @@ local should_run_generators
 local runner = {}
 
 runner.__current_generators = {}
+runner.__adding = false
 
 ---provided, the currently available generators from the cache will be run.
 ---Runs all the available generators and returns the found tasks.
 ---@param generators table|nil: A table of generators to run.
 ---If not provided, all available generators are run.
-function runner.run(generators)
-  if
-    not next(runner.__current_generators or {}) or not should_run_generators()
-  then
-    return
-  end
-  local cached_tasks = cache.get_for_current_context()
-  if cached_tasks then
+---@param add boolean?: When true, generators will run even
+---if the cache already exists, but the results will be added to the
+---cache instead of overriding it.
+---@param force boolean?: When true, the runner will run even if the
+---generators are currently being added.
+function runner.run(generators, add, force)
+  if not force and runner.__adding then
     return
   end
 
-  local found_tasks = {}
-
-  for _, generator in ipairs(generators or runner.__current_generators or {}) do
-    if generator:available() then
-      found_tasks = vim.tbl_extend("force", found_tasks, generator:run() or {})
+  local ok, err = pcall(function()
+    if
+      not next(runner.__current_generators or {})
+      or not should_run_generators()
+    then
+      return
     end
-  end
+    local cached_tasks = nil
+    if not add then
+      cached_tasks = cache.get_for_current_context()
+      if cached_tasks then
+        return
+      end
+    end
 
-  cache.set_for_current_context(found_tasks)
+    local found_tasks = {}
+
+    for _, generator in ipairs(generators or runner.__current_generators or {}) do
+      if generator:available() then
+        found_tasks =
+          vim.tbl_extend("force", found_tasks, generator:run() or {})
+      end
+    end
+
+    if add then
+      cache.add_to_current_context(found_tasks)
+    else
+      cache.set_for_current_context(found_tasks)
+    end
+  end)
+  if not ok and type(err) == "string" then
+    vim.notify(err, vim.log.levels.ERROR, {
+      title = enum.TITLE,
+    })
+  end
 end
 
 ---Create the BufEnter and DirChanged autocomands.
@@ -53,8 +79,8 @@ function runner.init()
       runner.run()
     end,
   })
-  if not next(runner.__current_generators or {}) then
-    runner.run()
+  if next(runner.__current_generators or {}) then
+    runner.run(nil, true)
   end
 end
 
@@ -62,7 +88,6 @@ end
 ---@return boolean: Whether the generators should be run
 should_run_generators = function()
   local buf = vim.fn.bufnr()
-
   local buftype = vim.api.nvim_buf_get_option(buf, "buftype")
   return buftype:len() == 0
 end

--- a/lua/telescope/_extensions/tasks/model/default_generator.lua
+++ b/lua/telescope/_extensions/tasks/model/default_generator.lua
@@ -13,6 +13,12 @@ local Default_generator = {
 }
 Default_generator.__index = Default_generator
 
+---@paran o table?
+---@return Default_generator
+function Default_generator:new(o)
+  return setmetatable(o or {}, Default_generator)
+end
+
 ---@return table: Generator function on index 1 and
 ---options on index 2.
 function Default_generator:get_generator()

--- a/lua/telescope/_extensions/tasks/model/generator.lua
+++ b/lua/telescope/_extensions/tasks/model/generator.lua
@@ -1,7 +1,7 @@
 local enum = require "telescope._extensions.tasks.enum"
 local Task = require "telescope._extensions.tasks.model.task"
 local Generator_opts =
-require "telescope._extensions.tasks.model.generator_opts"
+  require "telescope._extensions.tasks.model.generator_opts"
 
 ---@class Generator
 ---@field generator function
@@ -13,7 +13,7 @@ Generator.__index = Generator
 
 ---@param o table|function
 ---@return Generator
-function Generator.new(o)
+function Generator:new(o)
   if type(o) == "function" then
     o = { generator = o }
   end
@@ -27,7 +27,7 @@ function Generator.new(o)
     return generator
   end
 
-  generator.opts = Generator_opts.new(generator.opts)
+  generator.opts = Generator_opts:new(generator.opts)
   local name = generator.opts.name or generator.name
 
   generator.name = name
@@ -65,14 +65,15 @@ function Generator:run()
   end
   local found_tasks = {}
   for _, o in pairs(tasks) do
-    local task
-    ok, task = pcall(Task.new, o, self.opts)
-    if not ok and type(task) == "string" then
-      vim.notify(task, vim.log.levels.WARN, {
+    local err
+    ok, err = pcall(function()
+      local task = Task:new(o, self.opts)
+      found_tasks[task.name] = task
+    end)
+    if not ok and type(err) == "string" then
+      vim.notify(err, vim.log.levels.WARN, {
         title = enum.TITLE,
       })
-    else
-      found_tasks[task.name] = task
     end
   end
   return found_tasks

--- a/lua/telescope/_extensions/tasks/model/task.lua
+++ b/lua/telescope/_extensions/tasks/model/task.lua
@@ -14,7 +14,7 @@ Task.__index = Task
 ---@param o table|string: Task's fields or just a command.
 ---@param generator_opts table|nil: The options of the generator that created this task.
 ---@return Task
-function Task.new(o, generator_opts)
+function Task:new(o, generator_opts)
   ---@type Task
   local a = {
     __generator_opts = generator_opts,

--- a/lua/telescope/_extensions/tasks/picker/finder.lua
+++ b/lua/telescope/_extensions/tasks/picker/finder.lua
@@ -11,9 +11,15 @@ local get_task_display
 ---
 ---@return table: a telescope finder
 function finder.available_tasks_finder()
+  local cached_tasks = cache.get_current_tasks()
   local tasks = {}
-  for _, task in pairs(cache.get_current_tasks()) do
+  for _, task in pairs(cached_tasks) do
     table.insert(tasks, task)
+  end
+  for _, task in pairs(executor.get_running_tasks()) do
+    if not cached_tasks[task.name] then
+      table.insert(tasks, task)
+    end
   end
 
   return finders.new_table {

--- a/lua/telescope/_extensions/tasks/picker/init.lua
+++ b/lua/telescope/_extensions/tasks/picker/init.lua
@@ -1,27 +1,20 @@
 local enum = require "telescope._extensions.tasks.enum"
 local finder = require "telescope._extensions.tasks.picker.finder"
+local executor = require "telescope._extensions.tasks.executor"
 local previewer = require "telescope._extensions.tasks.picker.previewer"
 local mappings = require "telescope._extensions.tasks.picker.mappings"
 local cache = require "telescope._extensions.tasks.generators.cache"
 
 local pickers = require "telescope.pickers"
 local conf = require("telescope.config").values
-local picker = {}
 
-local available_tasks_telescope_picker
-
----Displays available tasks in a telescope prompt.
----In the opened window.
----
----@param opts table?: options to pass to the picker
-function picker.available_tasks_picker(opts)
-  available_tasks_telescope_picker(opts)
-end
-
-available_tasks_telescope_picker = function(options)
+local available_tasks_telescope_picker = function(options)
   local tasks = cache.get_current_tasks()
 
-  if tasks == nil or next(tasks) == nil then
+  if
+    next(tasks or {}) == nil
+    and next(executor.get_running_tasks() and {}) == nil
+  then
     vim.notify("There are no available tasks", vim.log.levels.WARN, {
       title = enum.TITLE,
     })
@@ -45,7 +38,11 @@ available_tasks_telescope_picker = function(options)
       :find()
   end
 
-  tasks_picker(options)
+  vim.defer_fn(function()
+    tasks_picker(options)
+  end, 0)
 end
 
-return picker.available_tasks_picker
+return function(opts)
+  available_tasks_telescope_picker(opts)
+end

--- a/lua/telescope/_extensions/tasks/picker/previewer.lua
+++ b/lua/telescope/_extensions/tasks/picker/previewer.lua
@@ -25,7 +25,9 @@ function previewer.task_previewer()
     end,
     scroll_fn = scroll_fn,
     teardown = teardown_fn,
-    preview_fn = preview_fn,
+    preview_fn = function(self, entry, status)
+      preview_fn(self, entry, status)
+    end,
   }
 end
 


### PR DESCRIPTION
Keep running tasks and tasks with output in the telescope picker
- They will keep properties from when they were available, so nothing weird should happen. 

Fix issues with invalid picker buffer. The picker might have changed since the start and the end of the task's execution, so a different buffer number should be used.

Refactor default generators, clean up some code