### PR TITLE
Allow running tasks with arguments

### DIFF
--- a/CUSTOM_GENERATORS.md
+++ b/CUSTOM_GENERATORS.md
@@ -59,9 +59,10 @@ custom.add {
 
 ## Task Spec
 
-| Property          | Type                | Description                                                                        |
-| ----------------- | ------------------- | ---------------------------------------------------------------------------------- |
-| **name** or `[1]` | `string`            | The name of the task.                                                              |
-| **cmd**           | `string` or `table` | A command to be executed. When a table, the first element should be an executable. |
-| **env**           | `table?`            | A table of environment variables used during the task's execution .                |
-| **cwd**           | `string?`           | A path to a directory that will be used as a working directory for the task.       |
+| Property           | Type                | Description                                                                                                                                                                                         |
+| ------------------ | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **name** or `[1]`  | `string`            | The name of the task.                                                                                                                                                                               |
+| **cmd**            | `string` or `table` | A command to be executed. When a table, the first element should be an executable.                                                                                                                  |
+| **env**            | `table?`            | A table of environment variables used during the task's execution .                                                                                                                                 |
+| **cwd**            | `string?`           | A path to a directory that will be used as a working directory for the task.                                                                                                                        |
+| **before_running** | `function?`         | A function that returns a string or a table of strings. It is called every time before running the task and the result is added to the end of command. This is useful for asking for arguments etc. |

--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ You may either use the [Default Generators](./DEFAULT_GENERATORS.md), or add [Cu
 
 ## Mappings
 
-| Key     | Description                                                                                                                               |
-| ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `<CR>`  | Run the selected task, or kill it if it is already running.                                                                               |
-| `<C-o>` | Display the output of the selected task in another window.                                                                                |
-| `<C-d>` | Delete the output of the selected task.                                                                                                   |
-| `<C-k>` | Scroll the previewer up.                                                                                                                  |
-| `<C-j>` | Scroll the previewer down.                                                                                                                |
+| Key     | Description                                                 |
+| ------- | ----------------------------------------------------------- |
+| `<CR>`  | Run the selected task, or kill it if it is already running. |
+| `<C-i>` | Run the selected task with arguments.                       |
+| `<C-o>` | Display the output of the selected task in another window.  |
+| `<C-d>` | Delete the output of the selected task.                     |
+| `<C-k>` | Scroll the previewer up.                                    |
+| `<C-j>` | Scroll the previewer down.                                  |

--- a/lua/telescope/_extensions/tasks/picker/actions.lua
+++ b/lua/telescope/_extensions/tasks/picker/actions.lua
@@ -26,6 +26,22 @@ function actions.select_task(prompt_bufnr)
   refresh_picker(prompt_bufnr)
 end
 
+function actions.select_task_with_arguments(prompt_bufnr)
+  vim.notify("AA")
+  local selection = action_state.get_selected_entry()
+  local task = selection.value
+
+  if executor.is_running(task.name) then
+    executor.kill(task)
+    return
+  end
+
+  executor.run(task, function()
+    refresh_picker()
+  end, true)
+  refresh_picker(prompt_bufnr)
+end
+
 function actions.selected_task_output(prompt_bufnr)
   local selection = action_state.get_selected_entry()
   output.open(selection.value, function()

--- a/lua/telescope/_extensions/tasks/picker/mappings.lua
+++ b/lua/telescope/_extensions/tasks/picker/mappings.lua
@@ -5,6 +5,7 @@ local mappings = {}
 
 mappings.keys = {
   ["<CR>"] = actions.select_task,
+  ["<C-i>"] = actions.select_task_with_arguments,
   ["<C-o>"] = actions.selected_task_output,
   ["<C-d>"] = actions.delete_selected_task_output,
   ["<C-k>"] = telescope_actions.preview_scrolling_up,


### PR DESCRIPTION
A task may now be run with arguments, by using `<C-i>` in the tasks prompt.
  - If the task is already running, this will kill it, the same `<CR>` does.
  - Otherwise it will ask for input before running. The input may either be a string or a table of strings. The result will then be added to the command.
  
`before_running` function field may now be added to the custom task.
  - This function overrides the default input prompt when pressing `<C-i>`, but is also called every time when running the task