### PR TITLE
Don't open term when no output by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ require("telescope").setup {
         layout = "center", -- "bottom" | "left" | "right" | "center"
         scale = 0.4, -- output window to editor size ratio
         -- NOTE: layout and scale are only relevant when style == "float"
+        terminal = false, -- Open terminal when toggling output but there is no available output
       },
       -- other picker setup values
     },

--- a/lua/telescope/_extensions/tasks/output/init.lua
+++ b/lua/telescope/_extensions/tasks/output/init.lua
@@ -1,4 +1,5 @@
 local enum = require "telescope._extensions.tasks.enum"
+local setup = require "telescope._extensions.tasks.setup"
 local executor = require "telescope._extensions.tasks.executor"
 local buffer = require "telescope._extensions.tasks.output.buffer"
 local window = require "telescope._extensions.tasks.output.window"
@@ -49,6 +50,12 @@ function output.toggle_last()
   local buf, name = executor.get_last_task_output_buf()
 
   if not buf then
+    if not setup.opts.output.terminal then
+      vim.notify("There is no available output", vim.log.levels.WARN, {
+        title = enum.TITLE,
+      })
+      return
+    end
     local ok, _ = pcall(function()
       if not term_buf or not vim.api.nvim_buf_is_valid(term_buf) then
         term_buf = buffer.create()

--- a/lua/telescope/_extensions/tasks/setup.lua
+++ b/lua/telescope/_extensions/tasks/setup.lua
@@ -8,6 +8,7 @@ setup.opts = {
     style = "float", -- "split" | "vsplit"
     layout = "center", -- "bottom" | "left" | "right"
     scale = 0.4,
+    terminal = false,
   },
 }
 
@@ -25,9 +26,7 @@ function setup.setup(opts)
 
   local output_opts = setup.opts.output
   if opts.output then
-    output_opts.layout = opts.output.layout or output_opts.layout
-    output_opts.style = opts.output.style or output_opts.style
-    output_opts.scale = opts.output.scale or output_opts.scale
+    output_opts = vim.tbl_extend("force", output_opts, opts.output)
   end
 
   local opts_env = opts.env


### PR DESCRIPTION
add output.terminal option that enables this