### PR TITLE
Allow adding multiple commands to a single task

### DIFF
--- a/DEFAULT_GENERATORS.md
+++ b/DEFAULT_GENERATORS.md
@@ -21,9 +21,9 @@ Call any of the functions described bellow to enable just some of them.
 
 ## Available default generators
 
-| Function           | Description               |
-| ------------------ | ------------------------- |
-| `default.go()`     | Currently in progress ... |
-| `default.cargo()`  | Currently in progress ... |
-| `default.python()` | Currently in progress ... |
-| `default.docker()` | Currently in progress ... |
+| Function           | Description                                                                                                                                                               |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default.go()`     | Finds all Go projects in subdirectories and generates tasks for running or building them. If no `go.mod` file is found, generates a task for running the current Go file. |
+| `default.cargo()`  | Currently in progress ...                                                                                                                                                 |
+| `default.python()` | Currently in progress ...                                                                                                                                                 |
+| `default.docker()` | Currently in progress ...                                                                                                                                                 |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ require("telescope").setup {
         -- NOTE: layout and scale are only relevant when style == "float"
         terminal = false, -- Open terminal when toggling output but there is no available output
       },
+      --[[ Allow default generators to generate tasks for building projects aswell,
+        instead  of generating just tasks for running them. Example: `go build` ]]
+      enable_build_commands = false,
       -- other picker setup values
     },
   },

--- a/lua/telescope/_extensions/tasks/executor/popup.lua
+++ b/lua/telescope/_extensions/tasks/executor/popup.lua
@@ -1,0 +1,96 @@
+local popup = {}
+
+function popup.open(choices, selection_callback)
+  local bufnr = popup.create_buffer(choices)
+  local winid = popup.create_window(bufnr, popup.determine_win_size(choices))
+  popup.handle_window(bufnr, winid, selection_callback)
+end
+
+function popup.create_buffer(choices)
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, choices)
+  vim.api.nvim_buf_set_option(buf, "modifiable", false)
+  vim.api.nvim_buf_set_option(buf, "modified", false)
+  return buf
+end
+
+function popup.create_window(bufnr, height, width)
+  local winid = vim.api.nvim_open_win(bufnr, true, {
+    relative = "cursor",
+    row = 0,
+    col = 0,
+    anchor = "NW",
+    width = width,
+    height = height,
+    style = "minimal",
+    border = "rounded",
+    focusable = true,
+    noautocmd = true,
+  })
+  vim.api.nvim_win_set_option(winid, "cursorline", true)
+  vim.api.nvim_win_set_option(
+    winid,
+    "winhl",
+    "NormalFloat:TelescopePromptNormal,FloatBorder:TelescopePromptBorder"
+  )
+  vim.api.nvim_exec("stopinsert", true)
+  return winid
+end
+
+function popup.handle_window(bufnr, winid, selection_callback)
+  vim.api.nvim_create_autocmd({ "BufEnter", "BufLeave", "FocusLost" }, {
+    buffer = bufnr,
+    callback = function()
+      vim.api.nvim_win_close(winid, true)
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end,
+  })
+  for _, k in ipairs { "<Esc>", "q" } do
+    vim.keymap.set("", k, function()
+      vim.api.nvim_exec_autocmds("FocusLost", { buffer = bufnr })
+    end)
+  end
+
+  vim.keymap.set("", "<Tab>", function()
+    popup.scroll(bufnr, winid, false)
+  end, { buffer = bufnr })
+  vim.keymap.set("", "<S-Tab>", function()
+    popup.scroll(bufnr, winid, true)
+  end, { buffer = bufnr })
+
+  vim.keymap.set("", "<CR>", function()
+    local line = vim.api.nvim_get_current_line()
+    vim.api.nvim_exec_autocmds("FocusLost", { buffer = bufnr })
+    selection_callback(line)
+  end, {
+    buffer = bufnr,
+  })
+end
+
+function popup.determine_win_size(choices)
+  local height = math.max(#choices, 1)
+  local width = 20
+  for _, s in ipairs(choices) do
+    if s:len() + 10 > width then
+      width = s:len() + 10
+    end
+  end
+  return height, width
+end
+
+function popup.scroll(bufnr, winid, up)
+  local cursor = vim.api.nvim_win_get_cursor(winid)
+  local linenr = cursor[1]
+  local lines = vim.api.nvim_buf_line_count(bufnr)
+
+  local new_line = up and linenr - 1 or linenr + 1
+  if new_line < 1 then
+    new_line = lines
+  elseif new_line > lines then
+    new_line = 1
+  end
+
+  vim.api.nvim_win_set_cursor(winid, { new_line, 0 })
+end
+
+return popup

--- a/lua/telescope/_extensions/tasks/generators/default.lua
+++ b/lua/telescope/_extensions/tasks/generators/default.lua
@@ -9,21 +9,21 @@ function default.all()
   return default.go(), default.cargo(), default.python()
 end
 
----Enable Go default run_project generator
+---Enable Go default generator
 function default.go()
   return add_generator(
     require "telescope._extensions.tasks.generators.default.go"
   )
 end
 
----Enable Cargo default run_project generator
+---Enable Cargo default generator
 function default.cargo()
   return add_generator(
     require "telescope._extensions.tasks.generators.default.cargo"
   )
 end
 
----Enable Python run_project generator
+---Enable Python generator
 function default.python()
   return add_generator(
     require "telescope._extensions.tasks.generators.default..python"

--- a/lua/telescope/_extensions/tasks/generators/env.lua
+++ b/lua/telescope/_extensions/tasks/generators/env.lua
@@ -7,6 +7,10 @@ local ENV = {
       BUILD_FLAGS = {},
       ARGUMENTS = {},
     },
+    BUILD = {
+      -- go build [build flags]
+      BUILD_FLAGS = {},
+    },
     ENV = {
       -- GOOS = "linux"
       -- ...

--- a/lua/telescope/_extensions/tasks/picker/actions.lua
+++ b/lua/telescope/_extensions/tasks/picker/actions.lua
@@ -22,8 +22,9 @@ function actions.select_task(prompt_bufnr)
 
   executor.run(task, function()
     refresh_picker()
+  end, function()
+    refresh_picker(prompt_bufnr)
   end)
-  refresh_picker(prompt_bufnr)
 end
 
 function actions.select_task_with_arguments(prompt_bufnr)
@@ -38,8 +39,9 @@ function actions.select_task_with_arguments(prompt_bufnr)
 
   executor.run(task, function()
     refresh_picker()
+  end, function()
+    refresh_picker(prompt_bufnr)
   end, true)
-  refresh_picker(prompt_bufnr)
 end
 
 function actions.selected_task_output(prompt_bufnr)

--- a/lua/telescope/_extensions/tasks/setup.lua
+++ b/lua/telescope/_extensions/tasks/setup.lua
@@ -10,6 +10,7 @@ setup.opts = {
     scale = 0.4,
     terminal = false,
   },
+  enable_build_commands = false,
 }
 
 ---Creates the default picker options from the provided
@@ -28,6 +29,7 @@ function setup.setup(opts)
   if opts.output then
     output_opts = vim.tbl_extend("force", output_opts, opts.output)
   end
+  
 
   local opts_env = opts.env
 


### PR DESCRIPTION
multiple commands should be given as a table with string values to the task's cmd field.

Added `run` and `build` commands for go projects
 - NOTE: by default `build` tasks are disabled, enable them with `enable_build_commands = true` in setup.