### PR TITLE
Make go project tasks' names relative to current cwd

### DIFF
--- a/lua/telescope/_extensions/tasks/generators/default/go.lua
+++ b/lua/telescope/_extensions/tasks/generators/default/go.lua
@@ -46,7 +46,7 @@ function go.generator(buf)
         --project in the found file's directory.
         local cwd = path:parent():__tostring()
         local full_path = path:__tostring()
-        path:make_relative(root:__tostring())
+        path:make_relative(vim.fn.getcwd())
         local name = "Go project: " .. path:__tostring()
         table.insert(tasks, run_project_task(cwd, name, full_path))
       elseif entry == vim.api.nvim_buf_get_name(buf) then


### PR DESCRIPTION
instead of their go.mod file's parent directory, this caused some names to be equal and therefore some tasks missing