### PR TITLE
fix: 'invalid order function for sorting' when nothing running

### DIFF
--- a/lua/telescope/_extensions/tasks/picker/finder.lua
+++ b/lua/telescope/_extensions/tasks/picker/finder.lua
@@ -95,9 +95,10 @@ local function get_tasks_ordering(tasks, new)
       return true
     elseif a_timestamp == nil and b_timestamp ~= nil then
       return false
+    elseif a_timestamp == nil and b_timestamp == nil then
+      return a < b
     end
-    return a_timestamp == nil and b_timestamp == nil
-        or a_timestamp > b_timestamp
+    return a_timestamp > b_timestamp
   end)
   return task_names
 end


### PR DESCRIPTION
If nothing running:
```
Error executing Lua callback: ...s.nvim/lua/telescope/_extensions/tasks/picker/finder.lua:77: invalid order function for sorting
stack traceback:
	[C]: in function 'sort'
	...s.nvim/lua/telescope/_extensions/tasks/picker/finder.lua:77: in function 'get_tasks_ordering'
	...s.nvim/lua/telescope/_extensions/tasks/picker/finder.lua:108: in function 'order_tasks'
	...s.nvim/lua/telescope/_extensions/tasks/picker/finder.lua:25: in function 'available_tasks_finder'
	...sks.nvim/lua/telescope/_extensions/tasks/picker/init.lua:10: in function 'available_tasks_telescope_picker'
	...sks.nvim/lua/telescope/_extensions/tasks/picker/init.lua:38: in function 'picker'
	...telescope-tasks.nvim/lua/telescope/_extensions/tasks.lua:23: in function <...telescope-tasks.nvim/lua/telescope/_extensions/tasks.lua:21>
	...share/nvim/lazy/telescope.nvim/lua/telescope/command.lua:193: in function 'run_command'
	...share/nvim/lazy/telescope.nvim/lua/telescope/command.lua:253: in function 'load_command'
	...ocal/share/nvim/lazy/telescope.nvim/plugin/telescope.lua:108: in function <...ocal/share/nvim/lazy/telescope.nvim/plugin/telescope.lua:107>
```