### PR TITLE
Feature/makefile generator

### DIFF
--- a/DEFAULT_GENERATORS.md
+++ b/DEFAULT_GENERATORS.md
@@ -21,9 +21,10 @@ Call any of the functions described bellow to enable just some of them.
 
 ## Available default generators
 
-| Function           | Description                                                                                                                                                               |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `default.go()`     | Finds all Go projects in subdirectories and generates tasks for running or building them. If no `go.mod` file is found, generates a task for running the current Go file. |
-| `default.lua()`    | Generates a task for running a current lua file.                                                                                                                          |
-| `default.cargo()`  | Currently in progress ...                                                                                                                                                 |
-| `default.python()` | Currently in progress ...                                                                                                                                                 |
+| Function             | Description                                                                                                                                                               |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default.go()`       | Finds all Go projects in subdirectories and generates tasks for running or building them. If no `go.mod` file is found, generates a task for running the current Go file. |
+| `default.makefile()` | Finds all makefiles in subdirectories and generates tasks for all targets.                                                                                                |
+| `default.lua()`      | Generates a task for running a current lua file.                                                                                                                          |
+| `default.cargo()`    | Currently in progress ...                                                                                                                                                 |
+| `default.python()`   | Currently in progress ...                                                                                                                                                 |

--- a/README.md
+++ b/README.md
@@ -79,13 +79,16 @@ You may either use the [Default Generators](./DEFAULT_GENERATORS.md), or add [Cu
 
 ## Mappings
 
-| Key     | Description                                                                              |
-| ------- | ---------------------------------------------------------------------------------------- |
-| `<CR>`  | Run the selected task, or kill it if it is already running.                              |
-| `<C-a>` | Run the selected task, but allow modifying the command before running it.                |
-| `<C-e>` | Run the selected task, allow modifying the command, but don't save the modified command. |
-| `<C-o>` | Display the output of the selected task in another window.                               |
-| `<C-r>` | Remove the output of the selected task.                                                  |
-| `<C-u>` | Scroll the previewer up.                                                                 |
-| `<C-d>` | Scroll the previewer down.                                                               |
-| `<C-q>` | Send a task's output to quickfix.                                                        |
+| Key        | Description                                                                              |
+| ---------- | ---------------------------------------------------------------------------------------- |
+| `<CR>`     | Run the selected task, or kill it if it is already running.                              |
+| `<C-a>`    | Run the selected task, but allow modifying the command before running it.                |
+| `<C-e>`    | Run the selected task, allow modifying the command, but don't save the modified command. |
+| `<C-o>`    | Display the output of the selected task in another window.                               |
+| `<C-r>`    | Remove the output of the selected task.                                                  |
+| `<C-u>`    | Scroll the previewer up.                                                                 |
+| `<C-d>`    | Scroll the previewer down.                                                               |
+| `<C-q>`    | Send a task's output to quickfix.                                                        |
+| `e`        | Edit the selected task's associated file (only in normal mode).                          |
+| `o`        | same as `<C-o>` but only in normal mode.                                                 |
+| `r` or `d` | same as `<C-r>` but only in normal mode.                                                 |

--- a/lua/telescope/_extensions/tasks/generators/default.lua
+++ b/lua/telescope/_extensions/tasks/generators/default.lua
@@ -2,7 +2,11 @@ local default = {}
 
 ---Enable all default generators
 function default.all()
-  return default.go(), default.cargo(), default.python(), default.lua()
+  return default.go(),
+    default.cargo(),
+    default.python(),
+    default.lua(),
+    default.makefile()
 end
 
 ---Enable Go default generator
@@ -23,6 +27,11 @@ end
 ---Enable Lua default generator
 function default.lua()
   require("telescope._extensions.tasks.generators.default.lua"):load()
+end
+
+---Enable Makefile default generator
+function default.makefile()
+  require("telescope._extensions.tasks.generators.default.makefile"):load()
 end
 
 return default

--- a/lua/telescope/_extensions/tasks/generators/default/go.lua
+++ b/lua/telescope/_extensions/tasks/generators/default/go.lua
@@ -69,6 +69,7 @@ run_project_task = function(cwd, name, full_path)
     name,
     cmd = cmd,
     cwd = cwd,
+    filename = full_path,
     __meta = {
       name = "go_run_project_" .. full_path:gsub("/", "_"):gsub("\\", "-"),
     },

--- a/lua/telescope/_extensions/tasks/generators/default/lua.lua
+++ b/lua/telescope/_extensions/tasks/generators/default/lua.lua
@@ -29,6 +29,7 @@ function lua.generator(buf)
   local t = {
     "Run current Lua file",
     cmd = cmd,
+    filename = name,
     __meta = {
       name = "lua_run_file_" .. name:gsub("/", "_"):gsub("\\", "-"),
     },

--- a/lua/telescope/_extensions/tasks/generators/default/makefile.lua
+++ b/lua/telescope/_extensions/tasks/generators/default/makefile.lua
@@ -37,6 +37,7 @@ function get_task(path, target)
 
   local t = {
     relative_path .. ": " .. target,
+    filename = path:__tostring(),
     cmd = { "make", target },
     cwd = cwd,
   }

--- a/lua/telescope/_extensions/tasks/generators/default/makefile.lua
+++ b/lua/telescope/_extensions/tasks/generators/default/makefile.lua
@@ -1,0 +1,49 @@
+local Default = require "telescope._extensions.tasks.model.default_generator"
+local Path = require "plenary.path"
+
+local makefile = Default:new {
+  opts = {
+    name = "Default Makefile targets Generator",
+    experimental = true,
+  },
+}
+
+local get_task
+
+function makefile.generator()
+  local files = makefile:state():find_files()
+  local tasks = {}
+
+  for _, n in ipairs { "makefile", "Makefile" } do
+    for _, m in ipairs(files[n] or {}) do
+      m = Path.new(m)
+      local ok, lines = pcall(m.readlines, m)
+      if ok then
+        for _, line in ipairs(lines) do
+          if not line:match "^%s*#" and line:match "^%w+%:" then
+            local target = line:match "^%w+"
+            table.insert(tasks, get_task(m, target))
+          end
+        end
+      end
+    end
+  end
+  return tasks
+end
+
+function get_task(path, target)
+  local relative_path = path:make_relative(vim.fn.getcwd())
+  local cwd = path:parent():__tostring()
+
+  local t = {
+    relative_path .. ": " .. target,
+    cmd = { "make", target },
+    cwd = cwd,
+  }
+  if type(vim.g.MAKEFILE_ENV) == "table" and next(vim.g.MAKEFILE_ENV) then
+    t.env = vim.g.MAKEFILE_ENV
+  end
+  return t
+end
+
+return makefile

--- a/lua/telescope/_extensions/tasks/generators/default/python.lua
+++ b/lua/telescope/_extensions/tasks/generators/default/python.lua
@@ -28,6 +28,7 @@ function python.generator(buf)
   local t = {
     "Run current Python file",
     cmd = cmd,
+    filename = name,
     __meta = {
       name = "python_run_file_" .. name:gsub("/", "_"):gsub("\\", "-"),
     },

--- a/lua/telescope/_extensions/tasks/model/default_generator.lua
+++ b/lua/telescope/_extensions/tasks/model/default_generator.lua
@@ -14,10 +14,6 @@ function Default_generator:new(o)
     type(o) == "table",
     "Default_generator should be created from a table"
   )
-  assert(
-    type(o.errorformat) == "string",
-    "Default_generator should have a string errorformat field"
-  )
   return setmetatable(o or {}, Default_generator)
 end
 

--- a/lua/telescope/_extensions/tasks/model/task.lua
+++ b/lua/telescope/_extensions/tasks/model/task.lua
@@ -5,6 +5,7 @@ local setup = require "telescope._extensions.tasks.setup"
 ---@field name string: This is taken from the key in vim.g.telescope_tasks table
 ---@field env table: A table of environment variables.
 ---@field cmd table|string: The command, may either be a string or a table. When a table, the first element should be executable.
+---@field filename string?: The task's reference file, which may be opened from the picker.
 ---@field cwd string: The working directory of the task.
 ---@field errorformat string|nil
 ---@field __generator_opts table|nil
@@ -58,6 +59,13 @@ function Task:new(o, generator_opts)
     "Task '" .. a.name .. "'s `errorformat` field should be a string!"
   )
   a.errorformat = errorformat
+
+  local filename = o.filename
+  assert(
+    filename == nil or type(filename) == "string",
+    "Task '" .. a.name .. "'s `filename` field should be a string!"
+  )
+  a.filename = filename
 
   local cmd = o.cmd
   assert(

--- a/lua/telescope/_extensions/tasks/picker/actions.lua
+++ b/lua/telescope/_extensions/tasks/picker/actions.lua
@@ -2,7 +2,6 @@ local util = require "telescope._extensions.tasks.util"
 local executor = require "telescope._extensions.tasks.executor"
 local finder = require "telescope._extensions.tasks.picker.finder"
 local output = require "telescope._extensions.tasks.output"
-
 local telescope_actions = require "telescope.actions"
 local action_state = require "telescope.actions.state"
 
@@ -25,6 +24,17 @@ function actions.select_task(prompt_bufnr)
   end, function()
     refresh_picker(prompt_bufnr)
   end, true, false)
+end
+
+function actions.edit_task_file(prompt_bufnr)
+  local selection = action_state.get_selected_entry()
+  local task = selection.value
+  if not task or not task.filename then
+    util.warn "Selected task has no associated filename"
+    return
+  end
+
+  telescope_actions.file_edit(prompt_bufnr)
 end
 
 function actions.run_task_with_modyfiable_command(prompt_bufnr)
@@ -95,7 +105,7 @@ refresh_picker = function(picker_buf, close_on_no_results)
     return
   end
   local tasks_finder =
-      finder.available_tasks_finder(p.starting_buffer, close_on_no_results)
+    finder.available_tasks_finder(p.starting_buffer, close_on_no_results)
   if not tasks_finder then
     pcall(telescope_actions.close, picker_buf)
     return

--- a/lua/telescope/_extensions/tasks/picker/finder.lua
+++ b/lua/telescope/_extensions/tasks/picker/finder.lua
@@ -30,6 +30,7 @@ function finder.available_tasks_finder(buf, exit_on_no_results, sort)
       return {
         value = entry,
         ordinal = entry.name,
+        filename = entry.filename,
         display = function(entry2)
           return get_task_display(entry2.value)
         end,

--- a/lua/telescope/_extensions/tasks/picker/mappings.lua
+++ b/lua/telescope/_extensions/tasks/picker/mappings.lua
@@ -5,6 +5,10 @@ local mappings = {}
 
 mappings.keys = {
   ["<CR>"] = actions.select_task,
+  ["e"] = actions.edit_task_file,
+  ["o"] = actions.selected_task_output,
+  ["r"] = actions.delete_selected_task_output,
+  ["d"] = actions.delete_selected_task_output,
   ["<C-a>"] = actions.run_task_and_save_modified_command,
   ["<C-e>"] = actions.run_task_with_modyfiable_command,
   ["<C-o>"] = actions.selected_task_output,
@@ -24,7 +28,11 @@ function mappings.attach_mappings(prompt_bufnr, map)
         f(prompt_bufnr)
       end)
     else
-      for _, mode in ipairs { "n", "i" } do
+      local modes = { "n" }
+      if key:sub(1, 2) == "<C" then
+        table.insert(modes, "i")
+      end
+      for _, mode in ipairs(modes) do
         map(mode, key, function()
           f(prompt_bufnr)
         end)


### PR DESCRIPTION
- Add a default generator for Makefile targets
  - Finds all makefiles in subdirectories and generates tasks for all targets
 
- Add additional mappings:
  - `e`: Edits the selected task's associated file (ex. the Makefile of a makefile task) (only in normal mode)
  - `r` and `d`: Same as `<C-r>` but only in normal mode
  - `o` asame as `<C-o>` but only in normal mode